### PR TITLE
Fix examples, the required prefix was dropped

### DIFF
--- a/example/src/main/resources/META-INF/ignite-mod.json
+++ b/example/src/main/resources/META-INF/ignite-mod.json
@@ -5,7 +5,7 @@
   "requiredDependencies": [
     "ignite"
   ],
-  "requiredMixins": [
+  "mixins": [
     "mixins.example.core.json"
   ]
 }

--- a/readme.md
+++ b/readme.md
@@ -54,7 +54,7 @@ Example `META-INF/ignite-mod.json`:
   "id": "example",
   "version": "1.0.0",
   "target": "space.vectrix.example.ExampleMod",
-  "requiredMixins": [
+  "mixins": [
     "mixins.example.core.json"
   ]
 }


### PR DESCRIPTION
The commit 0b59cb448e6c253bdd0bc184e490d59a3e4ac289 dropped the required prefix