### PR TITLE
Bootstrap Services

### DIFF
--- a/api/src/main/java/space/vectrix/ignite/api/Blackboard.java
+++ b/api/src/main/java/space/vectrix/ignite/api/Blackboard.java
@@ -37,6 +37,7 @@ public final class Blackboard {
   private static final BlackboardMap BLACKBOARD = new BlackboardMap();
 
   public static final BlackboardMap.@NonNull Key<List<String>> LAUNCH_ARGUMENTS = key("ignite.launch.arguments", new TypeToken<List<String>>() {});
+  public static final BlackboardMap.@NonNull Key<String>       LAUNCH_SERVICE   = key("ignite.launch.service", TypeToken.of(String.class));
   public static final BlackboardMap.@NonNull Key<Path>         LAUNCH_JAR       = key("ignite.launch.jar", TypeToken.of(Path.class));
   public static final BlackboardMap.@NonNull Key<String>       LAUNCH_TARGET    = key("ignite.launch.target", TypeToken.of(String.class));
 

--- a/api/src/main/java/space/vectrix/ignite/api/Blackboard.java
+++ b/api/src/main/java/space/vectrix/ignite/api/Blackboard.java
@@ -52,11 +52,15 @@ public final class Blackboard {
     return Blackboard.BLACKBOARD.get(key).orElse(defaultValue);
   }
 
-  public static <T> @Nullable T setProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T value) {
-    return Blackboard.BLACKBOARD.computeIfAbsent(key, k -> value);
+  public static <T> void putProperty(final BlackboardMap.@NonNull Key<T> key, final @NonNull T value) {
+    Blackboard.BLACKBOARD.put(key, value);
   }
 
-  private static <T> BlackboardMap.@NonNull Key<T> key(final @NonNull String key, final @NonNull TypeToken<T> type) {
+  public static <T> void computeProperty(final BlackboardMap.@NonNull Key<T> key, final @Nullable T value) {
+    Blackboard.BLACKBOARD.computeIfAbsent(key, k -> value);
+  }
+
+  public static <T> BlackboardMap.@NonNull Key<T> key(final @NonNull String key, final @NonNull TypeToken<T> type) {
     return BlackboardMap.Key.getOrCreate(Blackboard.BLACKBOARD, key, type.getRawType());
   }
 }

--- a/api/src/main/java/space/vectrix/ignite/api/service/IBootstrapService.java
+++ b/api/src/main/java/space/vectrix/ignite/api/service/IBootstrapService.java
@@ -1,0 +1,31 @@
+package space.vectrix.ignite.api.service;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+
+/**
+ * A singleton instance of this, loaded by the bootstrapper to manipulate
+ * launch properties before they occur.
+ */
+public interface IBootstrapService {
+  /**
+   * The bootstrap service name.
+   *
+   * @return The name
+   */
+  @NonNull String name();
+
+  /**
+   * Returns {@code true} if the service is in the right environment
+   * to be used, otherwise returns {@code false}.
+   *
+   * @return Whether the service is in a valid environment
+   */
+  boolean validate();
+
+  /**
+   * Executes the underlying functions to manipulate the launch properties.
+   *
+   * @throws Throwable Any errors from the functions
+   */
+  void execute() throws Throwable;
+}

--- a/api/src/main/java/space/vectrix/ignite/api/service/IBootstrapService.java
+++ b/api/src/main/java/space/vectrix/ignite/api/service/IBootstrapService.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package space.vectrix.ignite.api.service;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/api/src/main/java/space/vectrix/ignite/api/util/BlackboardMap.java
+++ b/api/src/main/java/space/vectrix/ignite/api/util/BlackboardMap.java
@@ -43,8 +43,17 @@ public final class BlackboardMap {
     return Optional.ofNullable(key.type.cast(this.blackboardMap.get(key)));
   }
 
+  public <V> void put(final @NonNull Key<V> key, final V value) {
+    put(this.blackboardMap, key, value);
+  }
+
   public <V> @Nullable V computeIfAbsent(final @NonNull Key<V> key, final @NonNull Function<? super Key<V>, ? extends V> valueFunction) {
     return computeIfAbsent(this.blackboardMap, key, valueFunction);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <C1, C2, V> void put(final ConcurrentHashMap<C1, C2> map, final Key<V> key, final V value) {
+    map.put((C1) key, (C2) value);
   }
 
   @SuppressWarnings("unchecked")

--- a/launcher/src/main/java/space/vectrix/ignite/applaunch/service/BootstrapServiceHandler.java
+++ b/launcher/src/main/java/space/vectrix/ignite/applaunch/service/BootstrapServiceHandler.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package space.vectrix.ignite.applaunch.service;
 
 import cpw.mods.modlauncher.ServiceLoaderStreamUtils;
@@ -20,7 +44,7 @@ public final class BootstrapServiceHandler {
     this.bootstrapServiceLookup = ServiceLoaderStreamUtils.toMap(this.bootstrapHandlerServices, IBootstrapService::name);
   }
 
-  public @NonNull Optional<IBootstrapService> findService(final String name) {
+  public @NonNull Optional<IBootstrapService> findService(final @NonNull String name) {
     return Optional.ofNullable(this.bootstrapServiceLookup.get(name));
   }
 }

--- a/launcher/src/main/java/space/vectrix/ignite/applaunch/service/BootstrapServiceHandler.java
+++ b/launcher/src/main/java/space/vectrix/ignite/applaunch/service/BootstrapServiceHandler.java
@@ -1,0 +1,26 @@
+package space.vectrix.ignite.applaunch.service;
+
+import cpw.mods.modlauncher.ServiceLoaderStreamUtils;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.ignite.api.service.IBootstrapService;
+
+import java.util.Map;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+public final class BootstrapServiceHandler {
+  private final ServiceLoader<IBootstrapService> bootstrapHandlerServices;
+  private final Map<String, IBootstrapService> bootstrapServiceLookup;
+
+  public BootstrapServiceHandler() {
+    this.bootstrapHandlerServices = ServiceLoaderStreamUtils.errorHandlingServiceLoader(IBootstrapService.class, error -> {
+      final RuntimeException problem = new RuntimeException("Encountered an exception attempting to load a bootstrap service!", error);
+      problem.printStackTrace();
+    });
+    this.bootstrapServiceLookup = ServiceLoaderStreamUtils.toMap(this.bootstrapHandlerServices, IBootstrapService::name);
+  }
+
+  public @NonNull Optional<IBootstrapService> findService(final String name) {
+    return Optional.ofNullable(this.bootstrapServiceLookup.get(name));
+  }
+}

--- a/launcher/src/main/java/space/vectrix/ignite/applaunch/service/DummyBootstrapService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/applaunch/service/DummyBootstrapService.java
@@ -1,0 +1,21 @@
+package space.vectrix.ignite.applaunch.service;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.ignite.api.service.IBootstrapService;
+
+public final class DummyBootstrapService implements IBootstrapService {
+  @Override
+  public @NonNull String name() {
+    return "dummy";
+  }
+
+  @Override
+  public boolean validate() {
+    return true;
+  }
+
+  @Override
+  public void execute() throws Throwable {
+    // no-op
+  }
+}

--- a/launcher/src/main/java/space/vectrix/ignite/applaunch/service/DummyBootstrapService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/applaunch/service/DummyBootstrapService.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package space.vectrix.ignite.applaunch.service;
 
 import org.checkerframework.checker.nullness.qual.NonNull;

--- a/launcher/src/main/java/space/vectrix/ignite/applaunch/service/PaperclipBootstrapService.java
+++ b/launcher/src/main/java/space/vectrix/ignite/applaunch/service/PaperclipBootstrapService.java
@@ -1,0 +1,143 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.ignite.applaunch.service;
+
+import com.google.common.reflect.TypeToken;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.ignite.api.Blackboard;
+import space.vectrix.ignite.api.service.IBootstrapService;
+import space.vectrix.ignite.api.util.BlackboardMap;
+import space.vectrix.ignite.applaunch.agent.Agent;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.security.Permission;
+import java.util.regex.Pattern;
+
+@SuppressWarnings("UnstableApiUsage")
+public final class PaperclipBootstrapService implements IBootstrapService {
+  private static final BlackboardMap.@NonNull Key<String> MINECRAFT_VERSION_KEY = Blackboard.key("ignite.paperclip.minecraft", TypeToken.of(String.class));
+  private static final BlackboardMap.@NonNull Key<Path>   PAPERCLIP_JAR_KEY     = Blackboard.key("ignite.paperclip.jar", TypeToken.of(Path.class));
+  private static final BlackboardMap.@NonNull Key<String> PAPERCLIP_TARGET_KEY  = Blackboard.key("ignite.paperclip.target", TypeToken.of(String.class));
+
+  /**
+   * The minecraft version.
+   */
+  public static final @NonNull String MINECRAFT_VERSION = System.getProperty(PaperclipBootstrapService.MINECRAFT_VERSION_KEY.getName(), "1.16.5");
+
+  /**
+   * The paperclip jar path.
+   */
+  public static final @NonNull Path PAPERCLIP_JAR = Paths.get(System.getProperty(PaperclipBootstrapService.PAPERCLIP_JAR_KEY.getName(), "./paper.jar"));
+
+  /**
+   * The paperclip jar target class path.
+   */
+  public static final @NonNull String PAPERCLIP_TARGET = System.getProperty(PaperclipBootstrapService.PAPERCLIP_TARGET_KEY.getName(), "io.papermc.paperclip.Paperclip");
+
+  @Override
+  public @NonNull String name() {
+    return "paperclip";
+  }
+
+  @Override
+  public boolean validate() {
+    return true;
+  }
+
+  @Override
+  public void execute() throws Throwable {
+    final SecurityManager original = System.getSecurityManager();
+    try {
+      System.setSecurityManager(new PaperclipExitHandler());
+
+      // Set paperclip to patch only, we launch the server ourselves.
+      System.setProperty("paperclip.patchonly", "true");
+
+      // Load the paperclip jar on the provided ClassLoader via the Agent.
+      try {
+        Agent.addJar(PaperclipBootstrapService.PAPERCLIP_JAR);
+      } catch (final IOException exception) {
+        throw new IllegalStateException("Unable to add paperclip jar to classpath!");
+      }
+
+      // Launch Paperclip
+      try {
+        final Class<?> paperclipClass = Class.forName(PaperclipBootstrapService.PAPERCLIP_TARGET);
+        paperclipClass
+          .getMethod("main", String[].class)
+          .invoke(null, (Object) new String[0]);
+      } catch (final ClassNotFoundException exception) {
+        throw new RuntimeException(exception);
+      }
+    } catch (final Throwable throwable) {
+      if(throwable instanceof InvocationTargetException) {
+        final Throwable target = ((InvocationTargetException) throwable).getTargetException();
+        if(target instanceof PaperclipException) {
+          int code = ((PaperclipException) target).getCode();
+          if(code != 0) throw new RuntimeException("Program '" + this.name() + "' stopped, with exit code: " + code);
+        } else {
+          throw new RuntimeException(throwable);
+        }
+      } else {
+        throw new RuntimeException(throwable);
+      }
+    }
+
+    // Update the launch jar. (Forced)
+    Blackboard.putProperty(Blackboard.LAUNCH_JAR, this.getServerJar());
+
+    // Remove the patchonly flag and security manager.
+    System.getProperties().remove("paperclip.patchonly");
+    System.setSecurityManager(original);
+  }
+
+  public Path getServerJar() {
+    return Paths.get(String.format("./cache/patched_%s.jar", PaperclipBootstrapService.MINECRAFT_VERSION));
+  }
+
+  /* package */ class PaperclipException extends SecurityException {
+    private final int code;
+
+    /* package */ PaperclipException(final int code) {
+      this.code = code;
+    }
+
+    public int getCode() {
+      return this.code;
+    }
+  }
+
+  /* package */ class PaperclipExitHandler extends SecurityManager {
+    @Override
+    public void checkPermission(final @NonNull Permission permission) {
+      if(!permission.getName().startsWith("exitVM")) return;
+      int code = Integer.parseInt(permission.getName().split(Pattern.quote("."))[1]);
+      throw new PaperclipException(code);
+    }
+  }
+}

--- a/launcher/src/main/java/space/vectrix/ignite/launch/IgniteLaunch.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/IgniteLaunch.java
@@ -27,8 +27,8 @@ package space.vectrix.ignite.launch;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.ignite.api.Blackboard;
 import space.vectrix.ignite.api.Platform;
-import space.vectrix.ignite.applaunch.IgniteBootstrap;
 import space.vectrix.ignite.applaunch.mod.ModEngine;
 import space.vectrix.ignite.launch.inject.IgniteModule;
 import space.vectrix.ignite.launch.mod.IgniteModManager;
@@ -60,11 +60,11 @@ public final class IgniteLaunch {
 
     // Launch
     try {
-      if (!Files.exists(IgniteBootstrap.LAUNCH_JAR)) {
+      if (!Files.exists(Blackboard.getProperty(Blackboard.LAUNCH_JAR))) {
         throw new IllegalStateException("No launch jar was found!");
       } else {
         // Invoke the main method on the provided ClassLoader.
-        Class.forName(IgniteBootstrap.LAUNCH_TARGET, true, IgniteLaunch.class.getClassLoader())
+        Class.forName(Blackboard.getProperty(Blackboard.LAUNCH_TARGET), true, IgniteLaunch.class.getClassLoader())
           .getMethod("main", String[].class)
           .invoke(null, (Object) args);
       }

--- a/launcher/src/main/java/space/vectrix/ignite/launch/inject/IgniteModule.java
+++ b/launcher/src/main/java/space/vectrix/ignite/launch/inject/IgniteModule.java
@@ -28,11 +28,11 @@ import com.google.inject.AbstractModule;
 import com.google.inject.Provider;
 import com.google.inject.Scopes;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.ignite.api.Blackboard;
 import space.vectrix.ignite.api.Ignite;
 import space.vectrix.ignite.api.Platform;
 import space.vectrix.ignite.api.config.path.ConfigsPath;
 import space.vectrix.ignite.api.config.path.ModsPath;
-import space.vectrix.ignite.applaunch.IgniteBootstrap;
 import space.vectrix.ignite.launch.IgnitePlatform;
 
 import java.nio.file.Path;
@@ -58,14 +58,14 @@ public final class IgniteModule extends AbstractModule {
   /* package */ static final class ModsPathProvider implements Provider<Path> {
     @Override
     public final @NonNull Path get() {
-      return IgniteBootstrap.MOD_TARGET_PATH;
+      return Blackboard.getProperty(Blackboard.MOD_DIRECTORY_PATH);
     }
   }
 
   /* package */ static final class ConfigsPathProvider implements Provider<Path> {
     @Override
     public final @NonNull Path get() {
-      return IgniteBootstrap.CONFIG_TARGET_PATH;
+      return Blackboard.getProperty(Blackboard.CONFIG_DIRECTORY_PATH);
     }
   }
 }

--- a/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.api.service.IBootstrapService
+++ b/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.api.service.IBootstrapService
@@ -1,1 +1,2 @@
 space.vectrix.ignite.applaunch.service.DummyBootstrapService
+space.vectrix.ignite.applaunch.service.PaperclipBootstrapService

--- a/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.api.service.IBootstrapService
+++ b/launcher/src/main/resources/META-INF/services/space.vectrix.ignite.api.service.IBootstrapService
@@ -1,0 +1,1 @@
+space.vectrix.ignite.applaunch.service.DummyBootstrapService

--- a/readme.md
+++ b/readme.md
@@ -15,10 +15,36 @@ In order to build Ignite you simply need to run the `gradle` command. You can fi
 ## Launcher Usage
 
 The Ignite launcher must be executed instead of the Minecraft Server. Ignite will launch the Minecraft Server itself, additionally passing in any extra arguments you provide it.
+Usually you would want to put the launcher jar, and the server jar in the same directory. 
 
-`java -Dignite.launch.jar=./paper.jar -Dignite.launch.target=org.bukkit.craftbukkit.Main -Dignite.mod.directory=./plugins -Dignite.config.directory=./plugins -jar ignite-launcher.jar`
+This would then be run like `java -jar ignite-launcher.jar`. Any other parameters will be passed onto and effect the target server.
 
 **Note:** You must add the flag `-javaagent:./ignite-launcher.jar` if you're running Java 8 or below.
+
+**Note:** If the target jar is a Paper jar, then you may want to read about the bootstrap services below to make launching easier.
+
+### Properties
+
+Ignite has some properties that can be set on startup to change the launch target, mod directory and more. The following could be added to your startup script:
+
+- The bootstrap service to use. (e.g `-Dignite.launch.service=dummy`)
+- The path to the server jar. (e.g `-Dignite.launch.jar=./server.jar`)
+- The classpath to the server entry point. (e.g `-Dignite.launch.target=org.bukkit.craftbukkit.Main`)
+- The directory ignite mods will be located. (e.g `-Dignite.mod.directory=./mods`)
+- The directory ignite mod configs will be located. (e.g `-Dignite.config.directory=./configs`)
+
+### Bootstrap Services
+
+Bootstrap services provide platform specific modifications to the launch process. In most cases these platforms may not work without using their specified service.
+The following target jars will require you to use one:
+
+- Paperclip:
+  - Service name: `paperclip` (e.g `-Dignite.launch.service=paperclip`)
+  - The `ignite.launch.jar` property will be overridden by this service, so you do not need to set it manually.
+  - Extra properties:
+    - The minecraft server version paperclip will be patching. (e.g `-Dignite.paperclip.minecraft=1.16.5`)
+    - The path to the paperclip jar. (e.g `-Dignite.paperclip.jar=./paper.jar`)
+    - The classpath to the paperclip entry point. (e.g `-Dignite.paperclip.target=io.papermc.paperclip.Paperclip`)
 
 ## Mod Usage
 


### PR DESCRIPTION
The bootstrap services allow for platform-specific changes to the launch target. A common use case is getting paperclip to patch the jar then change the launch jar to the one it patched. You would apply the service by setting the `ignite.launch.service` property on launch to the name specified in the service (e.g `-Dignite.launch.service=paperclip`). 

These services may come with their own flags you can set, for instance, paperclip has flags for setting the Minecraft version, jar and target to the paperclip jar (e.g `-Dignite.paperclip.minecraft=1.16.4 -Dignite.paperclip.jar=./paper.jar -Dignite.paperclip.target=io.papermc.paperclip.Paperclip`).

These services will make it easier to get Ignite up and running with platforms that have unique requirements, like Paperclip, while keeping Ignite platform agnostic. 