### PR TITLE
Add custom command with permission to the example mod

### DIFF
--- a/example/build.gradle.kts
+++ b/example/build.gradle.kts
@@ -6,12 +6,20 @@ repositories {
   maven {
     url = uri("https://repo.spongepowered.org/maven/")
   }
+
+  maven {
+    url = uri("https://papermc.io/repo/repository/maven-public/")
+  }
+
 }
 
 dependencies {
   implementation(project(":ignite-api"))
 
   implementation("org.spongepowered:mixin:0.8.5")
+
+  compileOnly("org.spigotmc:spigot-api:1.16.5-R0.1-SNAPSHOT")
+
 }
 
 applyJarMetadata("space.vectrix.example")

--- a/example/src/main/java/space/vectrix/example/command/HelloCommand.java
+++ b/example/src/main/java/space/vectrix/example/command/HelloCommand.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package space.vectrix.example.command;
 
 import org.bukkit.command.CommandSender;

--- a/example/src/main/java/space/vectrix/example/command/HelloCommand.java
+++ b/example/src/main/java/space/vectrix/example/command/HelloCommand.java
@@ -1,0 +1,24 @@
+package space.vectrix.example.command;
+
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.defaults.BukkitCommand;
+
+public class HelloCommand extends BukkitCommand {
+
+
+  public HelloCommand(String name) {
+    super(name);
+    this.setPermission("example.hello");
+
+  }
+
+  @Override
+  public boolean execute(CommandSender commandSender, String currentAlias, String[] args) {
+    if (!testPermission(commandSender)) {
+      return true;
+    } else {
+      commandSender.sendMessage("Hello " + commandSender.getName());
+    }
+    return false;
+  }
+}

--- a/example/src/main/java/space/vectrix/example/mixin/core/MixinSimpleCommandMap.java
+++ b/example/src/main/java/space/vectrix/example/mixin/core/MixinSimpleCommandMap.java
@@ -1,3 +1,27 @@
+/*
+ * This file is part of Ignite, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
 package space.vectrix.example.mixin.core;
 
 import org.bukkit.command.Command;

--- a/example/src/main/java/space/vectrix/example/mixin/core/MixinSimpleCommandMap.java
+++ b/example/src/main/java/space/vectrix/example/mixin/core/MixinSimpleCommandMap.java
@@ -1,0 +1,25 @@
+package space.vectrix.example.mixin.core;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.SimpleCommandMap;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import space.vectrix.example.command.HelloCommand;
+
+@Mixin(value = SimpleCommandMap.class)
+public abstract class MixinSimpleCommandMap {
+
+  @Shadow
+  public abstract boolean register(String fallbackPrefix, Command command);
+
+  @Inject(method = "setDefaultCommands()V", at = @At("TAIL"), remap = false)
+  public void registerOwnCommands(CallbackInfo ci) {
+    this.register("example", new HelloCommand("hello"));
+  }
+}
+
+
+

--- a/example/src/main/resources/mixins.example.core.json
+++ b/example/src/main/resources/mixins.example.core.json
@@ -1,11 +1,12 @@
 {
   "required": true,
-  "minVersion": "0.6.15",
+  "minVersion": "0.8.5",
   "package": "space.vectrix.example.mixin.core",
   "plugin": "space.vectrix.example.mixin.plugins.CorePlugin",
   "target": "@env(DEFAULT)",
   "compatibilityLevel": "JAVA_8",
   "server": [
-    "MixinCraftServer"
+    "MixinCraftServer",
+    "MixinSimpleCommandMap"
   ]
 }


### PR DESCRIPTION
As proposed in the Discord-Channel, I took the time to add a simple way to add commands via mixins in a fast way.
I am not sure about side-effects, since we add them to the "default" bukkit commands, but as far as I've tested it, there should be nothing wrong about it!